### PR TITLE
feat: Add cross-app context support for monorepo workflow

### DIFF
--- a/.claude/commands/fe-check-types.md
+++ b/.claude/commands/fe-check-types.md
@@ -1,0 +1,1 @@
+../../apps/frontend/.claude/commands/check-types.md

--- a/.claude/commands/fe-dev-server.md
+++ b/.claude/commands/fe-dev-server.md
@@ -1,0 +1,1 @@
+../../apps/frontend/.claude/commands/dev-server.md

--- a/.claude/commands/fe-test-ui.md
+++ b/.claude/commands/fe-test-ui.md
@@ -1,0 +1,1 @@
+../../apps/frontend/.claude/commands/test-ui.md

--- a/.claude/commands/load-context.md
+++ b/.claude/commands/load-context.md
@@ -1,0 +1,55 @@
+---
+description: アプリ固有のコンテキストを読み込む
+argument-hint: <app-name: frontend|backend|backend-billing>
+allowed-tools: Read, Glob, LS
+model: haiku
+---
+
+# アプリコンテキスト読み込み
+
+指定されたアプリ（$ARGUMENTS）の設定を読み込み、以降の作業で活用できるようにします。
+
+## 実行手順
+
+1. **CLAUDE.md を読み込む**
+   - `apps/$ARGUMENTS/CLAUDE.md` を読んで内容を把握
+   - 重要なルール、アーキテクチャ、コマンドを要約
+
+2. **利用可能なコマンド一覧**
+   - `apps/$ARGUMENTS/.claude/commands/` 配下のファイルを列挙
+   - 各コマンドの description を抽出して一覧表示
+
+3. **利用可能なスキル一覧**
+   - `apps/$ARGUMENTS/.claude/skills/` 配下のディレクトリを列挙
+   - 各スキルの SKILL.md があれば概要を抽出
+
+4. **ドキュメント一覧**
+   - `apps/$ARGUMENTS/.claude/docs/` 配下のファイルを列挙
+
+## 出力フォーマット
+
+```
+## $ARGUMENTS コンテキスト
+
+### 重要ルール
+- [CLAUDE.md から抽出した重要ルール]
+
+### 利用可能コマンド
+| コマンド | 説明 |
+|---------|------|
+| /xxx    | ... |
+
+### 利用可能スキル
+| スキル | 説明 |
+|-------|------|
+| xxx   | ... |
+
+### 関連ドキュメント
+- .claude/docs/xxx.md - 説明
+```
+
+## 注意
+
+- 指定されたアプリのディレクトリが存在しない場合はエラーを報告
+- .claude/ ディレクトリがない場合は CLAUDE.md のみを読み込む
+- 以降の作業では、読み込んだコンテキストを考慮して対応すること


### PR DESCRIPTION
## Summary
- Add `/load-context` command to dynamically load app-specific CLAUDE.md, commands, and skills
- Add symlinks for frontend commands (`/fe-check-types`, `/fe-test-ui`, `/fe-dev-server`)
- Enable working from root directory while leveraging app-specific configurations

## Test plan
- [ ] Run `/load-context frontend` and verify it loads frontend CLAUDE.md and lists available commands/skills
- [ ] Run `/load-context backend` and verify it loads backend CLAUDE.md
- [ ] Run `/fe-check-types` from root directory and verify it executes correctly
- [ ] Verify symlinks resolve correctly on clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)