### PR TITLE
feat: Add /simplify command wrapper for code-simplifier plugin

### DIFF
--- a/.claude/commands/simplify.md
+++ b/.claude/commands/simplify.md
@@ -1,0 +1,23 @@
+---
+description: コードの簡素化・リファクタリング（code-simplifierプラグインのラッパー）
+argument-hint: [対象ファイルまたはスコープ（省略時は最近の変更）]
+model: haiku
+---
+
+# Code Simplifier
+
+Skillツールを使用して `code-simplifier:code-simplifier` スキルを実行してください。
+
+## 引数
+
+$ARGUMENTS
+
+- 引数が指定されている場合: その対象に対してcode-simplifierを実行
+- 引数が空の場合: 最近変更されたコード（`git diff HEAD~1` または unstaged changes）を対象に実行
+
+## 実行
+
+```
+Skill: code-simplifier:code-simplifier
+Args: $ARGUMENTS
+```


### PR DESCRIPTION
## Summary

Add a slash command wrapper to make the official code-simplifier plugin accessible via `/simplify`.

## Changes

- Add `.claude/commands/simplify.md` - Wrapper command that invokes `code-simplifier:code-simplifier` skill
- Supports optional arguments for specifying target files/scope
- Defaults to recently modified code when no arguments provided

## Test plan

- [ ] Verify `/simplify` command appears in slash command list
- [ ] Test command execution without arguments (simplifies recent changes)
- [ ] Test command execution with file path argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)