### PR TITLE
README.mdのwindows環境でのhook設定とフォーマッタ不在時の警告メッセージを改善

### DIFF
--- a/.claude/hooks/format-code/README.md
+++ b/.claude/hooks/format-code/README.md
@@ -40,8 +40,69 @@ Write/Edit操作時に自動でファイルをフォーマットするPostToolUs
 
 ## セットアップ
 
-`.claude/settings.json`に以下を追加:
+### 1. hookスクリプトの配置確認
 
+このREADME.mdがあるディレクトリに `format-code.py` と `settings.json` があることを確認してください。
+
+### 2. settings.jsonの設定
+
+**重要**: 設定ファイルの場所とOSに応じて、適切な `command` パスを選択してください。
+
+#### パターン1: グローバル設定（ユーザーディレクトリ）
+
+**ファイル**: `~/.claude/settings.json` または `C:\Users\<username>\.claude\settings.json`
+
+**Linux/macOS**:
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/format-code/format-code.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Windows**:
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python %USERPROFILE%/.claude/hooks/format-code/format-code.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**説明**:
+- `%USERPROFILE%/.claude/` にhookスクリプトを配置した場合に使用
+- 全プロジェクトで共通のフォーマット設定を適用
+- Windowsでは `.py` ファイルを直接実行できないため、`python` コマンドプレフィックスが必要
+- `%USERPROFILE%` は Windows環境変数で、ユーザーのホームディレクトリに展開される（`~` は展開されない）
+
+#### パターン2: プロジェクト固有設定
+
+**ファイル**: `<project-root>/.claude/settings.json`
+
+**Linux/macOS**:
 ```json
 {
   "hooks": {
@@ -60,6 +121,61 @@ Write/Edit操作時に自動でファイルをフォーマットするPostToolUs
   }
 }
 ```
+
+**Windows**:
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python ./.claude/hooks/format-code/format-code.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**説明**:
+- プロジェクトの `.claude/` にhookスクリプトを配置した場合に使用
+- プロジェクトごとに異なるフォーマット設定を適用可能
+- 相対パス `./.claude/` は現在の作業ディレクトリ（プロジェクトルート）から解釈される
+
+### 3. OS判定とパス選択の自動化
+
+Claude Codeに以下のように依頼すると、自動的に適切な設定を選択・適用できます:
+
+```text
+このREADME.mdを読んで、私の環境（OS、設定ファイルの場所）に合わせてformat-code hookをセットアップしてください。
+```
+
+Claude Codeは以下の手順で自動設定します:
+
+1. **OS検出**: `platform` モジュールまたはシステムコマンドでOSを判定
+2. **設定ファイル検索**:
+   - グローバル設定: `~/.claude/settings.json` の存在確認
+   - プロジェクト設定: `./.claude/settings.json` の存在確認
+3. **パス決定**:
+   - hookスクリプトの場所に応じて、グローバル（`~/`）またはプロジェクト（`./`）パスを選択
+   - Windowsの場合は `python` プレフィックスを追加
+4. **設定追加**: 適切な `command` パスで `PostToolUse` hookを追加
+
+### 4. 手動設定の場合
+
+自分で設定する場合は、以下のチェックリストを確認:
+
+- [ ] hookスクリプトの場所を確認（`~/.claude/hooks/` または `<project>/.claude/hooks/`）
+- [ ] OSを確認（Windows の場合は `python` プレフィックスが必要）
+- [ ] 設定ファイルの場所を確認（グローバルまたはプロジェクト）
+- [ ] 上記のパターン1または2から適切な設定をコピー
+- [ ] `settings.json` に追記して保存
+- [ ] **Claude Code セッションを再起動**（hook設定の反映に必須）
 
 ## 設定
 
@@ -94,6 +210,34 @@ cp .claude/hooks/format-code/settings.json.example .claude/hooks/format-code/set
 - 複数コマンドは順番に試行し、最初に成功したものを使用
 - 全コマンドが未インストールの場合、警告とインストール方法を表示
 
+## エラー表示の仕組み
+
+このhookは、フォーマッターが見つからない場合や実行エラーが発生した場合、**ユーザーとClaudeの両方にエラーメッセージを表示**します。
+
+### Exit Codeとメッセージ表示
+
+| Exit Code | 出力先 | 動作 |
+|-----------|--------|------|
+| 0 | stdout | 成功。メッセージはtranscriptに記録（Claudeには非表示） |
+| 2 | stderr | ブロッキングエラー。**Claudeにフィードバックされ、ユーザーに表示** |
+
+### エラーメッセージの例
+
+**フォーマッター未インストール時**:
+```bash
+⚠️ FORMAT ERROR: Formatter not found for '.ts': prettier, eslint
+   💡 Install: npm install -g prettier  (or: npm install -g eslint)
+```
+
+**スクリプト実行エラー時**:
+```text
+⚠️ FORMAT HOOK ERROR: Invalid JSON input
+```
+
+### 動作確認
+
+フォーマッターがインストールされていないファイルを編集すると、自動的にエラーメッセージとインストール方法が表示されます。
+
 ## テスト実行
 
 ```bash
@@ -102,4 +246,7 @@ cp .claude/hooks/format-code/settings.json.example .claude/hooks/format-code/set
 
 # 直接実行
 pytest .claude/hooks/format-code/test/ -v
+
+# 手動テスト（コマンドライン）
+echo '{"tool_input": {"file_path": "/path/to/file.py"}}' | python format-code.py
 ```

--- a/.claude/hooks/format-code/format-code.py
+++ b/.claude/hooks/format-code/format-code.py
@@ -258,9 +258,9 @@ def format_file(file_path: str, formatter_map: dict) -> tuple[bool, str]:
 
     # All formatters missing → warn user
     if missing_cmds:
-        msg = f"Formatter not found for '{ext}': {', '.join(missing_cmds)}"
+        msg = f"⚠️ FORMAT ERROR: Formatter not found for '{ext}': {', '.join(missing_cmds)}"
         if install_hint:
-            msg += f"\n  Install: {install_hint}"
+            msg += f"\n   💡 Install: {install_hint}"
         return False, msg
 
     # Formatters exist but all failed
@@ -281,17 +281,24 @@ def main():
 
         success, message = format_file(file_path, formatter_map)
 
-        if message:
-            print(message)
-
-        sys.exit(0 if success else 1)
+        if not success and message:
+            # Exit 2 with stderr = blocking error shown to Claude
+            print(message, file=sys.stderr, flush=True)
+            sys.exit(2)
+        elif message:
+            # Success message to stdout
+            print(message, flush=True)
+            sys.exit(0)
+        else:
+            # Silent success
+            sys.exit(0)
 
     except json.JSONDecodeError:
-        print("Error: Invalid JSON input", file=sys.stderr)
-        sys.exit(1)
+        print("⚠️ FORMAT HOOK ERROR: Invalid JSON input", file=sys.stderr, flush=True)
+        sys.exit(2)
     except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+        print(f"⚠️ FORMAT HOOK ERROR: {e}", file=sys.stderr, flush=True)
+        sys.exit(2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Windows環境でのPython実行パス設定を明確化
- format-code.pyでフォーマッタ不在時にインストールを促す警告メッセージを表示