### PR TITLE
docs: Add multi-user GITHUB_TOKEN handling to github-cli.md

### DIFF
--- a/.claude/rules/github-cli.md
+++ b/.claude/rules/github-cli.md
@@ -18,3 +18,12 @@ gh pr view -R "$GH_REPO" <number>
 ```
 
 **Reason**: Local proxy URLs (127.0.0.1:48480) prevent gh from auto-detecting the repository.
+
+## Multi-User Environment
+
+複数ユーザーで共有する環境では、`GITHUB_TOKEN` が別ユーザーのトークンで設定されている場合がある。
+gh CLI 実行前に `unset GITHUB_TOKEN` で環境変数をクリアし、`gh auth` の認証情報を使用すること。
+
+```bash
+unset GITHUB_TOKEN && gh pr list -R "$GH_REPO"
+```


### PR DESCRIPTION
## Summary

複数ユーザー環境での `GITHUB_TOKEN` 競合問題への対処手順を追加。

## Changes

- `.claude/rules/github-cli.md` に「Multi-User Environment」セクション追加
- `unset GITHUB_TOKEN` で環境変数をクリアしてから `gh` CLI を実行する手順を記載

🤖 Generated with [Claude Code](https://claude.ai/claude-code)