### PR TITLE
refactor: Update settings.json.example to flat command format

### DIFF
--- a/.claude/hooks/format-code/settings.json.example
+++ b/.claude/hooks/format-code/settings.json.example
@@ -3,25 +3,25 @@
     {
       "extensions": [".py", ".pyi"],
       "commands": [
-        [["ruff", "format", "{file}"], ["black", "{file}"]],
-        [["ruff", "check", "--fix", "{file}"]]
+        ["ruff", "format", "{file}"],
+        ["ruff", "check", "--fix", "{file}"]
       ],
-      "install_hint": "pip install ruff  (or: pip install black)",
+      "install_hint": "pip install ruff",
       "enabled": true
     },
     {
       "extensions": [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"],
       "commands": [
-        [["prettier", "--write", "{file}"]],
-        [["eslint", "--fix", "{file}"]]
+        ["prettier", "--write", "{file}"],
+        ["eslint", "--fix", "{file}"]
       ],
-      "install_hint": "npm install -g prettier  (or: npm install -g eslint)",
+      "install_hint": "npm install -g prettier eslint",
       "enabled": true
     },
     {
       "extensions": [".json", ".yaml", ".yml"],
       "commands": [
-        [["prettier", "--write", "{file}"]]
+        ["prettier", "--write", "{file}"]
       ],
       "install_hint": "npm install -g prettier",
       "enabled": true
@@ -29,7 +29,7 @@
     {
       "extensions": [".sh", ".bash"],
       "commands": [
-        [["shfmt", "-i", "2", "-w", "{file}"]]
+        ["shfmt", "-i", "2", "-w", "{file}"]
       ],
       "install_hint": "go install mvdan.cc/sh/v3/cmd/shfmt@latest  (or: brew install shfmt)",
       "enabled": true
@@ -37,8 +37,8 @@
     {
       "extensions": [".go"],
       "commands": [
-        [["gofmt", "-w", "{file}"]],
-        [["goimports", "-w", "{file}"]]
+        ["gofmt", "-w", "{file}"],
+        ["goimports", "-w", "{file}"]
       ],
       "install_hint": "Go toolchain includes gofmt. goimports: go install golang.org/x/tools/cmd/goimports@latest",
       "enabled": true
@@ -46,7 +46,7 @@
     {
       "extensions": [".rs"],
       "commands": [
-        [["rustfmt", "{file}"]]
+        ["rustfmt", "{file}"]
       ],
       "install_hint": "rustup component add rustfmt",
       "enabled": true
@@ -54,7 +54,7 @@
     {
       "extensions": [".css", ".scss", ".less"],
       "commands": [
-        [["prettier", "--write", "{file}"]]
+        ["prettier", "--write", "{file}"]
       ],
       "install_hint": "npm install -g prettier",
       "enabled": true
@@ -62,7 +62,7 @@
     {
       "extensions": [".html", ".htm"],
       "commands": [
-        [["prettier", "--write", "{file}"]]
+        ["prettier", "--write", "{file}"]
       ],
       "install_hint": "npm install -g prettier",
       "enabled": true
@@ -70,7 +70,7 @@
     {
       "extensions": [".md", ".mdx"],
       "commands": [
-        [["__markdown__"]]
+        ["__markdown__"]
       ],
       "enabled": true
     }


### PR DESCRIPTION
## Summary

`settings.json.example` を新しいフラットなコマンド形式に更新。

PR #20 で `format-code.py` の構造を `Array<Step<Alternative>>` → `Array<Command>` に簡素化したが、exampleファイルが旧形式のままだったため同期。

## Changes

- `.claude/hooks/format-code/settings.json.example` - `[[[]]]` → `[[]]` 形式に変更、black フォールバック削除

🤖 Generated with [Claude Code](https://claude.ai/claude-code)