### PR TITLE
feat: add completion sound hook for task finish

### DIFF
--- a/.claude/hooks/sounds/complete-sound.sh
+++ b/.claude/hooks/sounds/complete-sound.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# 完了音（キラキラ） - Claudeがタスク完了時に鳴らす
+# WSL2環境でPowerShellを呼び出してビープ音を鳴らす
+
+powershell.exe -NoProfile -NonInteractive "
+[console]::beep(523, 80)
+[console]::beep(659, 80)
+[console]::beep(783, 80)
+[console]::beep(1046, 120)
+" 2>/dev/null
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,18 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/sounds/complete-sound.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "matcher": "",


### PR DESCRIPTION
## Summary
- タスク完了時（Stopイベント）に完了音を鳴らすhookを追加
- WSL2環境でPowerShellのビープ音を使用（キラキラ音）

## Test plan
- [x] `claude`でタスク実行後、完了音が鳴ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)