### PR TITLE
feat: add OS platform emoji to statusline

### DIFF
--- a/.claude/hooks/statusline/README.md
+++ b/.claude/hooks/statusline/README.md
@@ -15,6 +15,11 @@ Claude Codeのステータスラインをカスタマイズし、モデル名、
 
 ## 機能
 
+- **プラットフォーム表示**: OS環境を絵文字で表示
+  - 🪟 Windows
+  - 🐧 Linux/WSL
+  - 🍎 macOS
+  - 💻 その他
 - **モデル表示**: 現在使用中のモデル名を表示（例: Sonnet 4.5）
 - **ディレクトリ表示**: 現在の作業ディレクトリ名を表示
 - **トークン使用量**: 現在のコンテキスト使用量を表示（K/M単位）
@@ -26,7 +31,7 @@ Claude Codeのステータスラインをカスタマイズし、モデル名、
 ## 表示例
 
 ```
-[Sonnet 4.5] 📁 my-project | 🪙 45.2K | 68%
+🪟 [Sonnet 4.5] 📁 my-project | 🪙 45.2K | 68%
 ```
 
 ## セットアップ
@@ -174,7 +179,8 @@ const percentageColor =
 ### 表示フォーマットを変更
 
 ```javascript
-return `[${model}] 📁 ${currentDir} | 🪙 ${tokenDisplay} | ${percentageColor}${percentage}%\x1b[0m`;
+const osEmoji = getPlatformEmoji();
+return `${osEmoji} [${model}] 📁 ${currentDir} | 🪙 ${tokenDisplay} | ${percentageColor}${percentage}%\x1b[0m`;
 ```
 
 ## トラブルシューティング
@@ -229,8 +235,10 @@ Statusline hookは標準入力からJSONデータを受け取ります:
 ANSIエスケープコードを使用して色付きテキストを標準出力に返します:
 
 ```
-[Model] 📁 directory | 🪙 tokens | color%
+🪟 [Model] 📁 directory | 🪙 tokens | color%
 ```
+
+先頭のOS絵文字は `process.platform` により自動検出されます。
 
 ### 使用率計算
 

--- a/.claude/hooks/statusline/statusline.js
+++ b/.claude/hooks/statusline/statusline.js
@@ -3,6 +3,32 @@
 const path = require("path");
 
 /**
+ * Detect OS platform and return appropriate emoji
+ * @returns {string}
+ */
+const getPlatformEmoji = () => {
+  try {
+    const platform = process.platform;
+
+    if (platform === 'win32') {
+      return '🪟';
+    }
+
+    if (platform === 'darwin') {
+      return '🍎';
+    }
+
+    if (platform === 'linux') {
+      return '🐧';  // WSLもLinuxもペンギン
+    }
+
+    return '💻';  // フォールバック
+  } catch (err) {
+    return '💻';
+  }
+};
+
+/**
  * @param {number} tokens
  * @returns {string}
  */
@@ -47,7 +73,8 @@ const buildStatusLine = (input) => {
         ? "\x1b[33m" // Yellow
         : "\x1b[32m"; // Green
 
-  return `[${model}] 📁 ${currentDir} | 🪙 ${tokenDisplay} | ${percentageColor}${percentage}%\x1b[0m`;
+  const osEmoji = getPlatformEmoji();
+  return `${osEmoji} [${model}] 📁 ${currentDir} | 🪙 ${tokenDisplay} | ${percentageColor}${percentage}%\x1b[0m`;
 };
 
 const chunks = [];


### PR DESCRIPTION
## Summary

ステータスラインにOS環境を示す絵文字を追加しました。

## Changes

- プラットフォーム検出関数 `getPlatformEmoji()` を追加
- ステータスライン表示にOS絵文字を先頭に配置
- README.mdに機能説明と表示例を追加

## Platform Emojis

- 🪟 Windows
- 🐧 Linux/WSL
- 🍎 macOS
- 💻 Fallback

## Example

```
🪟 [Sonnet 4.5] 📁 my-project | 🪙 45.2K | 68%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)