### PR TITLE
fix: use context window size instead of 80% limit for percentage calculation

### DIFF
--- a/.claude/hooks/statusline/README.md
+++ b/.claude/hooks/statusline/README.md
@@ -243,8 +243,7 @@ ANSIエスケープコードを使用して色付きテキストを標準出力�
 ### 使用率計算
 
 ```javascript
-const autoCompactLimit = contextSize * 0.8;
-const percentage = Math.min(100, Math.round((currentTokens / autoCompactLimit) * 100));
+const percentage = Math.min(100, Math.round((currentTokens / contextSize) * 100));
 ```
 
-コンテキストウィンドウの80%を基準として使用率を計算します。
+コンテキストウィンドウの上限を基準として使用率を計算します。

--- a/.claude/hooks/statusline/statusline.js
+++ b/.claude/hooks/statusline/statusline.js
@@ -53,7 +53,6 @@ const buildStatusLine = (input) => {
   const contextWindow = data.context_window || {};
   const contextSize = contextWindow.context_window_size;
   const currentUsage = contextWindow.current_usage;
-  const autoCompactLimit = contextSize * 0.8;
 
   const currentTokens =
     (currentUsage.input_tokens || 0) +
@@ -62,7 +61,7 @@ const buildStatusLine = (input) => {
 
   const percentage = Math.min(
     100,
-    Math.round((currentTokens / autoCompactLimit) * 100),
+    Math.round((currentTokens / contextSize) * 100),
   );
   const tokenDisplay = formatTokenCount(currentTokens);
 


### PR DESCRIPTION
## Summary

ステータスラインのパーセンテージ計算を、自動コンパクトの80%基準（160K）から、コンテキストウィンドウ全体（200K）基準に変更し、より直感的な表示にしました。

## Changes

- `statusline.js`: `autoCompactLimit` 変数を削除し、`contextSize` で直接計算
- `README.md`: 使用率計算の説明を更新

## Motivation

自動コンパクト機能を理解しているユーザーにとって、80%基準の計算は混乱を招く可能性があります。実際のトークン使用量と表示パーセンテージの関係が直感的になります。

**Before:**
- 35.3K tokens → 22% (35.3K / 160K)

**After:**
- 35.3K tokens → 18% (35.3K / 200K)

## Test plan

- [x] ローカルで動作確認
- [x] README更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)