### PR TITLE
feat: Add session title display to statusline

### DIFF
--- a/.claude/hooks/statusline/statusline.js
+++ b/.claude/hooks/statusline/statusline.js
@@ -1,6 +1,82 @@
 #!/usr/bin/env node
 
 const path = require("path");
+const fs = require("fs");
+
+/**
+ * Get session summary (title) from sessions-index.json
+ * @param {string} transcriptPath - Path to the transcript file
+ * @returns {string} - Session summary or empty string
+ */
+const getSessionSummary = (transcriptPath) => {
+  try {
+    if (!transcriptPath) return "";
+
+    const projectDir = path.dirname(transcriptPath);
+    const sessionId = path.basename(transcriptPath, ".jsonl");
+    const indexPath = path.join(projectDir, "sessions-index.json");
+
+    // まずsessions-index.jsonから検索
+    if (fs.existsSync(indexPath)) {
+      const indexData = JSON.parse(fs.readFileSync(indexPath, "utf-8"));
+      const entries = indexData.entries || {};
+
+      for (const entry of Object.values(entries)) {
+        if (entry.sessionId === sessionId && entry.summary) {
+          const summary = entry.summary;
+          return summary.length > 15 ? summary.substring(0, 12) + "..." : summary;
+        }
+      }
+    }
+
+    // indexに無い場合、transcriptファイルから最初のユーザープロンプトを取得
+    if (fs.existsSync(transcriptPath)) {
+      const content = fs.readFileSync(transcriptPath, "utf-8");
+      const lines = content.split("\n").filter(line => line.trim());
+
+      for (const line of lines) {
+        try {
+          const entry = JSON.parse(line);
+          if (entry.type === "user" && entry.message?.content) {
+            let text = "";
+            const msgContent = entry.message.content;
+
+            // contentが配列の場合
+            if (Array.isArray(msgContent)) {
+              const textContent = msgContent.find(c => c.type === "text");
+              if (textContent?.text) {
+                text = textContent.text;
+              }
+            } else if (typeof msgContent === "string") {
+              // contentが文字列の場合
+              text = msgContent;
+            }
+
+            // システムタグを除外してテキストを抽出
+            // <tag>...</tag> 形式のタグを繰り返し除去
+            let prevText;
+            do {
+              prevText = text;
+              text = text.replace(/<[^>]+>[\s\S]*?<\/[^>]+>/g, "");
+            } while (text !== prevText);
+            // 自己閉じタグも除去
+            text = text.replace(/<[^>]+\/>/g, "").trim();
+
+            if (text && text.length > 0) {
+              return text.length > 15 ? text.substring(0, 12) + "..." : text;
+            }
+          }
+        } catch (e) {
+          continue;
+        }
+      }
+    }
+
+    return "";
+  } catch (err) {
+    return "";
+  }
+};
 
 /**
  * Detect OS platform and return appropriate emoji
@@ -73,7 +149,9 @@ const buildStatusLine = (input) => {
         : "\x1b[32m"; // Green
 
   const osEmoji = getPlatformEmoji();
-  return `${osEmoji} [${model}] 📁 ${currentDir} | 🪙 ${tokenDisplay} | ${percentageColor}${percentage}%\x1b[0m`;
+  const summary = getSessionSummary(data.transcript_path);
+  const summaryPart = summary ? ` | 📝 ${summary}` : "";
+  return `${osEmoji} [${model}] 📁 ${currentDir}${summaryPart} | 🪙 ${tokenDisplay} | ${percentageColor}${percentage}%\x1b[0m`;
 };
 
 const chunks = [];


### PR DESCRIPTION
## Summary
- statuslineにセッションタイトル（📝アイコン）を表示
- 15文字を超える場合は省略表示
- sessions-index.jsonになければtranscriptファイルから取得

## Test plan
- [ ] 新規セッションでstatuslineにタイトルが表示されることを確認
- [ ] /resumeで再開したセッションでsummaryが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)